### PR TITLE
fix: permissive CORS for MCP gateway endpoints

### DIFF
--- a/app/core/middleware/mcp_cors.py
+++ b/app/core/middleware/mcp_cors.py
@@ -1,0 +1,48 @@
+"""Permissive CORS for MCP gateway paths.
+
+Claude.ai (and other remote MCP clients) need unrestricted CORS on the MCP
+gateway endpoints.  The main CORSMiddleware only allows app-specific origins,
+so this middleware intercepts MCP-related paths first and adds open CORS
+headers — including the ``Mcp-Session-Id`` header used by Streamable HTTP.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_MCP_PREFIXES = ("/mcp-gw/", "/.well-known/oauth", "/authorize", "/oauth/")
+
+_ALLOW_HEADERS = "Authorization, Content-Type, Accept, Mcp-Session-Id"
+_ALLOW_METHODS = "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+_EXPOSE_HEADERS = "Mcp-Session-Id"
+
+
+class McpCorsMiddleware(BaseHTTPMiddleware):
+    """Return permissive CORS headers for MCP gateway paths."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = request.url.path
+        if not any(path.startswith(p) for p in _MCP_PREFIXES):
+            return await call_next(request)
+
+        origin = request.headers.get("origin", "*")
+
+        # Preflight — answer immediately so the main CORSMiddleware never
+        # rejects the request with 400.
+        if request.method == "OPTIONS":
+            return Response(
+                status_code=204,
+                headers={
+                    "Access-Control-Allow-Origin": origin,
+                    "Access-Control-Allow-Methods": _ALLOW_METHODS,
+                    "Access-Control-Allow-Headers": _ALLOW_HEADERS,
+                    "Access-Control-Max-Age": "86400",
+                },
+            )
+
+        # Normal request — forward, then stamp CORS headers on the response.
+        response = await call_next(request)
+        response.headers["Access-Control-Allow-Origin"] = origin
+        response.headers["Access-Control-Allow-Headers"] = _ALLOW_HEADERS
+        response.headers["Access-Control-Expose-Headers"] = _EXPOSE_HEADERS
+        return response

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.core.middleware.tenant import TenantSchemaMiddleware
 from app.core.middleware.entity_scope import EntityScopeMiddleware
 from app.core.middleware.security_headers import SecurityHeadersMiddleware
 from app.core.middleware.rate_limit import RateLimitMiddleware
+from app.core.middleware.mcp_cors import McpCorsMiddleware
 from app.core.module_registry import ModuleRegistry
 from app.event_handlers import register_all_handlers
 from app.tasks.scheduler import start_scheduler, stop_scheduler
@@ -200,6 +201,7 @@ app.add_middleware(
     allow_headers=settings.cors_headers_list,
     expose_headers=["X-Request-Id"],
 )
+app.add_middleware(McpCorsMiddleware)
 
 if settings.ALLOWED_HOSTS != "*":
     app.add_middleware(


### PR DESCRIPTION
## Summary
- Claude.ai's "Connecter" button was failing with "couldn't reach MCP server" because the browser preflight CORS check was rejected (origin `https://claude.ai` not in allowed origins → HTTP 400)
- Added `McpCorsMiddleware` that intercepts `/mcp-gw/`, `/.well-known/oauth`, `/authorize`, `/oauth/` paths and returns permissive CORS headers before the restrictive `CORSMiddleware` can reject them
- Includes `Mcp-Session-Id` header support for MCP Streamable HTTP transport

## Test plan
- [ ] Deploy to VPS
- [ ] Go to claude.ai → Settings → Connectors → Gouti → click "Connecter"
- [ ] Verify the OAuth authorization page loads instead of "couldn't reach MCP server"
- [ ] Complete the OAuth flow with Bearer token
- [ ] Verify MCP tools are available in Claude.ai conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)