### PR TITLE
fix: add UI for employee transfer in Conformite module [SUP-0036]

### DIFF
--- a/apps/main/src/locales/en/common.json
+++ b/apps/main/src/locales/en/common.json
@@ -1199,7 +1199,18 @@
     },
     "transfers": {
       "title": "Transfers",
-      "create": "New transfer"
+      "create": "New transfer",
+      "create_subtitle": "Transfer an employee from one company to another",
+      "select_tier": "Select source company",
+      "select_tier_help": "Choose the current company of the employee",
+      "source_company": "Source company",
+      "select_employee": "Select employee",
+      "select_employee_help": "Choose the employee to transfer",
+      "destination": "Destination",
+      "destination_help": "Company to which the employee will be transferred",
+      "details": "Transfer details",
+      "details_help": "Additional information about the transfer",
+      "reason_placeholder": "E.g.: Contract change, reorganization..."
     },
     "check": {
       "compliant": "Compliant",
@@ -1293,7 +1304,14 @@
     "ex_mise_a_jour_duree_de_validite": "Ex: Mise à jour durée de validité...",
     "aucun_historique_disponible": "Aucun historique disponible.",
     "document_non_trouve_ou_deja_traite": "Document non trouve ou deja traite.",
-    "expliquez_pourquoi_ce_document_est_rejet": "Expliquez pourquoi ce document est rejete..."
+    "expliquez_pourquoi_ce_document_est_rejet": "Expliquez pourquoi ce document est rejete...",
+    "toast": {
+      "select_employee": "Please select an employee",
+      "select_tiers": "Please select source and destination companies",
+      "same_tier_error": "Source and destination companies must be different",
+      "transfer_created": "Transfer created successfully",
+      "transfer_creation_error": "Error creating transfer"
+    }
   },
   "projets": {
     "title": "Projects",

--- a/apps/main/src/locales/fr/common.json
+++ b/apps/main/src/locales/fr/common.json
@@ -1255,7 +1255,18 @@
     },
     "transfers": {
       "title": "Transferts",
-      "create": "Nouveau transfert"
+      "create": "Nouveau transfert",
+      "create_subtitle": "Transférer un employé d'un tiers vers un autre",
+      "select_tier": "Sélectionner l'entreprise source",
+      "select_tier_help": "Choisissez l'entreprise actuelle de l'employé",
+      "source_company": "Entreprise source",
+      "select_employee": "Sélectionner l'employé",
+      "select_employee_help": "Choisissez l'employé à transférer",
+      "destination": "Destination",
+      "destination_help": "Entreprise vers laquelle l'employé sera transféré",
+      "details": "Détails du transfert",
+      "details_help": "Informations complémentaires sur le transfert",
+      "reason_placeholder": "Ex: Changement de contrat, réorganisation..."
     },
     "check": {
       "compliant": "Conforme",
@@ -1343,7 +1354,12 @@
       "rejected": "Rejeté",
       "document_verified": "Document vérifié",
       "document_rejected": "Document rejeté",
-      "error": "Erreur"
+      "error": "Erreur",
+      "select_employee": "Veuillez sélectionner un employé",
+      "select_tiers": "Veuillez sélectionner les entreprises source et destination",
+      "same_tier_error": "L'entreprise source et destination doivent être différentes",
+      "transfer_created": "Transfert créé avec succès",
+      "transfer_creation_error": "Erreur lors de la création du transfert"
     },
     "auto_genere_a_la_creation": "Auto-genere a la creation",
     "description_du_type_de_conformite": "Description du type de conformite...",

--- a/apps/main/src/pages/conformite/ConformitePage.tsx
+++ b/apps/main/src/pages/conformite/ConformitePage.tsx
@@ -60,6 +60,7 @@ import { JobPositionDetailPanel } from './panels/JobPositionDetailPanel'
 import { CreateRulePanel } from './panels/CreateRulePanel'
 import { EditRulePanel } from './panels/EditRulePanel'
 import { VerificationDetailPanel } from './panels/VerificationDetailPanel'
+import { CreateTransferPanel } from './panels/CreateTransferPanel'
 
 // Tabs
 import { VerificationsTab } from './tabs/VerificationsTab'
@@ -106,6 +107,7 @@ export function ConformitePage() {
   const canCreateExemption = hasPermission('conformite.exemption.create')
   const canApproveExemption = hasPermission('conformite.exemption.approve')
   const canVerify = hasPermission('conformite.verify')
+  const canCreateTransfer = hasPermission('conformite.transfer.create')
 
   const dynamicPanel = useUIStore((s) => s.dynamicPanel)
   const openDynamicPanel = useUIStore((s) => s.openDynamicPanel)
@@ -271,8 +273,9 @@ export function ConformitePage() {
     if (activeTab === 'exemptions' && canCreateExemption) return <ToolbarButton icon={Plus} label={t('conformite.exemptions.create')} variant="primary" onClick={() => openDynamicPanel({ type: 'create', module: 'conformite', meta: { subtype: 'exemption' } })} />
     if (activeTab === 'enregistrements' && canCreateRecord) return <ToolbarButton icon={Plus} label={t('conformite.records.create')} variant="primary" onClick={() => openDynamicPanel({ type: 'create', module: 'conformite', meta: { subtype: 'record' } })} />
     if (activeTab === 'regles' && canCreateRule) return <ToolbarButton icon={Plus} label={t('conformite.rules.create')} variant="primary" onClick={() => openDynamicPanel({ type: 'create', module: 'conformite', meta: { subtype: 'rule' } })} />
+    if (activeTab === 'transferts' && canCreateTransfer) return <ToolbarButton icon={Plus} label={t('conformite.transfers.create')} variant="primary" onClick={() => openDynamicPanel({ type: 'create', module: 'conformite', meta: { subtype: 'transfer' } })} />
     return null
-  }, [activeTab, openDynamicPanel, canCreateType, canCreateRecord, canCreateJP, canCreateExemption, canCreateRule, t])
+  }, [activeTab, openDynamicPanel, canCreateType, canCreateRecord, canCreateJP, canCreateExemption, canCreateRule, canCreateTransfer, t])
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -443,6 +446,7 @@ export function ConformitePage() {
       {dynamicPanel?.module === 'conformite' && dynamicPanel.type === 'create' && dynamicPanel.meta?.subtype === 'rule' && <CreateRulePanel />}
       {dynamicPanel?.module === 'conformite' && dynamicPanel.type === 'edit' && dynamicPanel.meta?.subtype === 'rule' && <EditRulePanel />}
       {dynamicPanel?.module === 'conformite' && dynamicPanel.type === 'detail' && dynamicPanel.meta?.subtype === 'verification' && <VerificationDetailPanel id={dynamicPanel.id} recordType={dynamicPanel.meta?.record_type as string || ''} />}
+      {dynamicPanel?.module === 'conformite' && dynamicPanel.type === 'create' && dynamicPanel.meta?.subtype === 'transfer' && <CreateTransferPanel />}
     </div>
   )
 }
@@ -459,5 +463,6 @@ registerPanelRenderer('conformite', (view) => {
   if (view.type === 'create' && view.meta?.subtype === 'exemption') return <CreateExemptionPanel />
   if (view.type === 'detail' && 'id' in view && view.meta?.subtype === 'exemption') return <ExemptionDetailPanel id={view.id} />
   if (view.type === 'detail' && 'id' in view && view.meta?.subtype === 'verification') return <VerificationDetailPanel id={view.id} recordType={view.meta?.record_type as string || ''} />
+  if (view.type === 'create' && view.meta?.subtype === 'transfer') return <CreateTransferPanel />
   return null
 })

--- a/apps/main/src/pages/conformite/panels/CreateTransferPanel.tsx
+++ b/apps/main/src/pages/conformite/panels/CreateTransferPanel.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useMemo, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { GitBranch } from 'lucide-react'
+import { DynamicPanelShell, DynamicPanelField, panelInputClass, PanelContentLayout } from '@/components/layout/DynamicPanel'
+import {
+  SmartFormProvider,
+  SmartFormSection,
+  SmartFormToolbar,
+  SmartFormSimpleHint,
+  SmartFormWizardNav,
+  SmartFormInlineHelpDrawer,
+  useSmartForm,
+} from '@/components/layout/SmartForm'
+import type { ActionItem } from '@/components/layout/DynamicPanel'
+import { useUIStore } from '@/stores/uiStore'
+import { useToast } from '@/components/ui/Toast'
+import { useCreateTransfer } from '@/hooks/useConformite'
+import { useTiers, useTierContacts } from '@/hooks/useTiers'
+import type { TierContactTransferCreate } from '@/types/api'
+
+export function CreateTransferPanel() {
+  return (
+    <SmartFormProvider panelId="create-transfer" defaultMode="simple">
+      <CreateTransferInner />
+    </SmartFormProvider>
+  )
+}
+
+function CreateTransferInner() {
+  const _ctx = useSmartForm()
+  const { t } = useTranslation()
+  const createTransfer = useCreateTransfer()
+  const closeDynamicPanel = useUIStore((s) => s.closeDynamicPanel)
+  const { toast } = useToast()
+
+  // Fetch all tiers for dropdowns
+  const { data: tiersData } = useTiers({ page_size: 500 })
+
+  const [selectedContactTierId, setSelectedContactTierId] = useState<string>('')
+
+  // Fetch contacts for the selected tier
+  const { data: contactsData } = useTierContacts(selectedContactTierId || undefined)
+
+  const [form, setForm] = useState<TierContactTransferCreate>({
+    contact_id: '',
+    from_tier_id: '',
+    to_tier_id: '',
+    transfer_date: new Date().toISOString().split('T')[0],
+    reason: null,
+  })
+
+  // When a contact is selected, auto-populate from_tier_id with the contact's current tier
+  useEffect(() => {
+    if (form.contact_id && contactsData?.items) {
+      const selectedContact = contactsData.items.find((c) => c.id === form.contact_id)
+      if (selectedContact && selectedContact.tier_id) {
+        setForm((prev) => ({ ...prev, from_tier_id: selectedContact.tier_id }))
+      }
+    }
+  }, [form.contact_id, contactsData])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!form.contact_id) {
+      toast({ title: t('conformite.toast.select_employee'), variant: 'error' })
+      return
+    }
+    if (!form.from_tier_id || !form.to_tier_id) {
+      toast({ title: t('conformite.toast.select_tiers'), variant: 'error' })
+      return
+    }
+    if (form.from_tier_id === form.to_tier_id) {
+      toast({ title: t('conformite.toast.same_tier_error'), variant: 'error' })
+      return
+    }
+
+    try {
+      await createTransfer.mutateAsync(form)
+      closeDynamicPanel()
+      toast({ title: t('conformite.toast.transfer_created'), variant: 'success' })
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : t('conformite.toast.transfer_creation_error')
+      toast({ title: message, variant: 'error' })
+    }
+  }
+
+  const actionItems = useMemo<ActionItem[]>(() => [
+    { id: 'cancel', label: t('common.cancel'), priority: 40, onClick: closeDynamicPanel },
+    {
+      id: 'create',
+      label: t('common.create'),
+      variant: 'primary',
+      priority: 100,
+      loading: createTransfer.isPending,
+      disabled: createTransfer.isPending,
+      onClick: () => (document.getElementById('create-transfer-form') as HTMLFormElement)?.requestSubmit(),
+    },
+  ], [t, closeDynamicPanel, createTransfer.isPending])
+
+  const tiers = tiersData?.items ?? []
+  const contacts = contactsData?.items ?? []
+
+  return (
+    <DynamicPanelShell
+      title={t('conformite.transfers.create')}
+      subtitle={t('conformite.transfers.create_subtitle')}
+      icon={<GitBranch size={14} className="text-blue-500" />}
+      actionItems={actionItems}
+    >
+      <form id="create-transfer-form" onSubmit={handleSubmit}>
+        <PanelContentLayout>
+          <SmartFormToolbar />
+          <SmartFormSimpleHint />
+          <SmartFormInlineHelpDrawer />
+
+          <SmartFormSection
+            id="select_tier"
+            title={t('conformite.transfers.select_tier')}
+            level="essential"
+            help={{ description: t('conformite.transfers.select_tier_help') }}
+          >
+            <DynamicPanelField label={t('conformite.transfers.source_company')} required>
+              <select
+                required
+                value={selectedContactTierId}
+                onChange={(e) => {
+                  setSelectedContactTierId(e.target.value)
+                  setForm({ ...form, contact_id: '', from_tier_id: e.target.value })
+                }}
+                className={panelInputClass}
+              >
+                <option value="">-- {t('common.select')} --</option>
+                {tiers.map((tier) => (
+                  <option key={tier.id} value={tier.id}>
+                    {tier.name} ({tier.code})
+                  </option>
+                ))}
+              </select>
+            </DynamicPanelField>
+          </SmartFormSection>
+
+          <SmartFormSection
+            id="select_employee"
+            title={t('conformite.transfers.select_employee')}
+            level="essential"
+            help={{ description: t('conformite.transfers.select_employee_help') }}
+          >
+            <DynamicPanelField label={t('conformite.columns.employee')} required>
+              <select
+                required
+                value={form.contact_id}
+                onChange={(e) => setForm({ ...form, contact_id: e.target.value })}
+                className={panelInputClass}
+                disabled={!selectedContactTierId}
+              >
+                <option value="">-- {t('common.select')} --</option>
+                {contacts.map((contact) => (
+                  <option key={contact.id} value={contact.id}>
+                    {contact.first_name} {contact.last_name} {contact.email ? `(${contact.email})` : ''}
+                  </option>
+                ))}
+              </select>
+            </DynamicPanelField>
+          </SmartFormSection>
+
+          <SmartFormSection
+            id="destination"
+            title={t('conformite.transfers.destination')}
+            level="essential"
+            help={{ description: t('conformite.transfers.destination_help') }}
+          >
+            <DynamicPanelField label={t('conformite.columns.to')} required>
+              <select
+                required
+                value={form.to_tier_id}
+                onChange={(e) => setForm({ ...form, to_tier_id: e.target.value })}
+                className={panelInputClass}
+              >
+                <option value="">-- {t('common.select')} --</option>
+                {tiers
+                  .filter((tier) => tier.id !== form.from_tier_id)
+                  .map((tier) => (
+                    <option key={tier.id} value={tier.id}>
+                      {tier.name} ({tier.code})
+                    </option>
+                  ))}
+              </select>
+            </DynamicPanelField>
+          </SmartFormSection>
+
+          <SmartFormSection
+            id="details"
+            title={t('conformite.transfers.details')}
+            level="essential"
+            help={{ description: t('conformite.transfers.details_help') }}
+          >
+            <DynamicPanelField label={t('conformite.columns.date')} required>
+              <input
+                type="date"
+                required
+                value={form.transfer_date}
+                onChange={(e) => setForm({ ...form, transfer_date: e.target.value })}
+                className={panelInputClass}
+              />
+            </DynamicPanelField>
+
+            <DynamicPanelField label={t('common.reason')}>
+              <textarea
+                value={form.reason ?? ''}
+                onChange={(e) => setForm({ ...form, reason: e.target.value || null })}
+                className={`${panelInputClass} min-h-[80px] resize-y`}
+                placeholder={t('conformite.transfers.reason_placeholder')}
+                rows={3}
+              />
+            </DynamicPanelField>
+          </SmartFormSection>
+
+          {_ctx?.mode === 'wizard' && (
+            <SmartFormWizardNav
+              onSubmit={() => document.querySelector('form')?.requestSubmit()}
+              onCancel={() => {}}
+            />
+          )}
+        </PanelContentLayout>
+      </form>
+    </DynamicPanelShell>
+  )
+}

--- a/tests/test_conformite_transfer_ui.py
+++ b/tests/test_conformite_transfer_ui.py
@@ -1,0 +1,113 @@
+"""
+Test SUP-0036: Employee transfer functionality in Conformite UI.
+
+This test demonstrates that the backend transfer endpoint works correctly,
+but the frontend lacks a UI to trigger it.
+"""
+import pytest
+from datetime import date
+
+
+@pytest.mark.asyncio
+async def test_transfer_endpoint_exists_and_works(async_client, test_entity, test_user, db):
+    """
+    Verify that the backend API for creating transfers is functional.
+
+    This test proves the backend works - the bug is that the frontend
+    has no button/panel to call this endpoint.
+    """
+    from app.models.common import Tier, TierContact
+    from sqlalchemy import select
+
+    # Create two tiers (companies)
+    tier_a = Tier(
+        entity_id=test_entity.id,
+        name="Company A",
+        code="COMP_A",
+        type="subcontractor",
+        active=True,
+    )
+    tier_b = Tier(
+        entity_id=test_entity.id,
+        name="Company B",
+        code="COMP_B",
+        type="subcontractor",
+        active=True,
+    )
+    db.add_all([tier_a, tier_b])
+    await db.commit()
+    await db.refresh(tier_a)
+    await db.refresh(tier_b)
+
+    # Create an employee initially under Company A
+    employee = TierContact(
+        tier_id=tier_a.id,
+        first_name="John",
+        last_name="Doe",
+        email="john.doe@example.com",
+    )
+    db.add(employee)
+    await db.commit()
+    await db.refresh(employee)
+
+    # Verify employee is under Company A
+    assert employee.tier_id == tier_a.id
+
+    # Call the backend API to transfer employee from A to B
+    transfer_payload = {
+        "contact_id": str(employee.id),
+        "from_tier_id": str(tier_a.id),
+        "to_tier_id": str(tier_b.id),
+        "transfer_date": date.today().isoformat(),
+        "reason": "Contract change",
+    }
+
+    response = await async_client.post(
+        "/api/v1/conformite/transfers",
+        json=transfer_payload,
+    )
+
+    # Backend should succeed
+    assert response.status_code == 201, f"Transfer failed: {response.json()}"
+    transfer_data = response.json()
+
+    assert transfer_data["contact_id"] == str(employee.id)
+    assert transfer_data["from_tier_id"] == str(tier_a.id)
+    assert transfer_data["to_tier_id"] == str(tier_b.id)
+
+    # Verify the employee's tier_id was actually updated
+    await db.refresh(employee)
+    assert employee.tier_id == tier_b.id, "Employee should now belong to Company B"
+
+    # Verify transfer history was recorded
+    from app.models.common import TierContactTransfer
+
+    transfer_record = (
+        await db.execute(
+            select(TierContactTransfer).where(
+                TierContactTransfer.contact_id == employee.id
+            )
+        )
+    ).scalar_one_or_none()
+
+    assert transfer_record is not None, "Transfer should be logged in history"
+    assert transfer_record.from_tier_id == tier_a.id
+    assert transfer_record.to_tier_id == tier_b.id
+
+
+@pytest.mark.asyncio
+async def test_transfer_list_endpoint_works(async_client, test_entity, test_user, db):
+    """
+    Verify the GET /transfers endpoint works (this is what the UI displays).
+
+    The UI successfully shows the transfer list, but has no way to ADD to it.
+    """
+    response = await async_client.get("/api/v1/conformite/transfers")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Should return paginated response
+    assert "items" in data
+    assert "total" in data
+    assert isinstance(data["items"], list)


### PR DESCRIPTION
## 🎯 Résumé

Correction du ticket **SUP-0036** : implémentation de l'interface utilisateur manquante pour la création de transferts d'employés entre tiers dans le module Conformité.

## 🐛 Problème

L'onglet "Transferts" affichait l'historique des transferts mais ne proposait aucun bouton ni formulaire pour **créer** un nouveau transfert. L'implémentation backend était complète (endpoint API + logique métier), mais le lien frontend-backend n'était pas terminé.

## ✅ Solution

- ✨ **Nouveau composant** : `CreateTransferPanel.tsx` avec formulaire de transfert
  - Sélection de l'entreprise source
  - Sélection de l'employé à transférer
  - Sélection de l'entreprise de destination
  - Date de transfert + motif (optionnel)
  - Validation : source ≠ destination
- 🔘 **Bouton "+ Nouveau transfert"** dans la toolbar (permissions : `conformite.transfer.create`)
- 🌍 **Traductions** FR + EN pour tous les nouveaux textes
- 🧪 **Test d'intégration** démontrant que l'API backend fonctionne correctement

## 📊 Impact

- **Fichiers modifiés** : 5
  - 1 nouveau panel (~235 lignes)
  - 1 test backend (~95 lignes)
  - Modifications mineures dans ConformitePage + locales
- **Lignes** : +386 / -5
- **Modules touchés** : Conformité uniquement
- **Risque** : Faible (ajout de fonctionnalité isolée)

## 🧪 Validation

Le test `tests/test_conformite_transfer_ui.py` vérifie que :
1. L'endpoint `POST /api/v1/conformite/transfers` fonctionne
2. Le `tier_id` du contact est bien mis à jour
3. Un enregistrement d'historique est créé dans `TierContactTransfer`

Frontend : compiler avec `npx tsc --noEmit` dans `apps/main/` (✓ pas d'erreur)

## 📸 Parcours utilisateur

1. Ouvrir Conformité → onglet Transferts
2. Clic sur **"+ Nouveau transfert"**
3. Sélectionner l'entreprise source → liste des employés se charge
4. Sélectionner l'employé → le champ "De" se pré-remplit automatiquement
5. Sélectionner l'entreprise de destination (ne peut pas être la même que la source)
6. Renseigner la date et le motif (optionnel)
7. Soumettre → le transfert est créé, l'employé change de `tier_id`, l'historique est enregistré

Agent-Run: 5c9afdc2-a447-40e1-b189-b540458276a9