### PR TITLE
fix(conformite): SUP-0038 - Complete employee transfer implementation

### DIFF
--- a/alembic/versions/161_add_job_position_to_transfers.py
+++ b/alembic/versions/161_add_job_position_to_transfers.py
@@ -1,0 +1,30 @@
+"""Add new_job_position_id to tier_contact_transfers.
+
+Allows changing employee job position during transfer, which updates
+compliance requirements (different HSE certifications per position).
+
+Revision ID: 161_add_job_position_to_transfers
+Revises: 160_voyage_stop_pax_cargo_flow
+Create Date: 2026-05-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "161_add_job_position_to_transfers"
+down_revision: Union[str, None] = "160_voyage_stop_pax_cargo_flow"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tier_contact_transfers",
+        sa.Column("new_job_position_id", UUID(as_uuid=True), sa.ForeignKey("job_positions.id"), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tier_contact_transfers", "new_job_position_id")

--- a/app/api/routes/modules/conformite.py
+++ b/app/api/routes/modules/conformite.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, case, select, func as sqla_func, literal, any_, or_
+from sqlalchemy import and_, case, select, func as sqla_func, literal, any_, or_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import check_verified_lock, get_current_entity, get_current_user, require_module_enabled, require_permission
@@ -1162,6 +1162,39 @@ async def delete_job_position(
 # ── Employee Transfers ───────────────────────────────────────────────────
 
 
+async def _invalidate_compliance_on_transfer(db: AsyncSession, contact_id: UUID) -> None:
+    """
+    SUP-0038: Invalidate existing compliance records when an employee is transferred.
+
+    When an employee changes tier (company) or job position, their compliance
+    requirements may change (different HSE certifications, different contextual rules).
+    We mark existing compliance records as inactive to force re-verification in the new context.
+
+    This ensures:
+    1. Old compliance records from previous context don't count as valid
+    2. New compliance checks reflect the current tier/job requirements
+    3. Compliance officers must re-verify/re-issue documents for the new context
+
+    Note: We mark records as active=False rather than deleting them to preserve audit trail.
+    """
+    await db.execute(
+        update(ComplianceRecord)
+        .where(
+            ComplianceRecord.owner_type == "tier_contact",
+            ComplianceRecord.owner_id == contact_id,
+            ComplianceRecord.active == True,
+        )
+        .values(active=False)
+    )
+    # Emit event for audit trail (optional, if event system is enabled)
+    await emit_event(
+        event_type="compliance.invalidated_on_transfer",
+        entity_type="tier_contact",
+        entity_id=contact_id,
+        data={"reason": "Employee transfer - context changed"},
+    )
+
+
 @router.get("/transfers", response_model=PaginatedResponse[TierContactTransferRead], dependencies=[require_permission("conformite.transfer.read")])
 async def list_transfers(
     contact_id: UUID | None = None,
@@ -1227,7 +1260,11 @@ async def create_transfer(
     _: None = require_permission("conformite.transfer.create"),
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a transfer record and update the contact's tier_id."""
+    """Create a transfer record and update the contact's tier_id (and optionally job_position_id).
+
+    SUP-0038: Also invalidates existing compliance records and triggers re-verification
+    in the new context (new tier + new job position if provided).
+    """
     # Validate contact exists AND belongs to the caller's entity (via parent tier)
     contact_row = await db.execute(
         select(TierContact)
@@ -1255,6 +1292,24 @@ async def create_transfer(
             code="TIER_NOT_FOUND",
             message="Tier not found",
         )
+
+    # Validate new job position if provided (SUP-0038)
+    if body.new_job_position_id:
+        jp_check = await db.execute(
+            select(JobPosition).where(
+                JobPosition.id == body.new_job_position_id,
+                JobPosition.entity_id == entity_id,
+                JobPosition.active == True,
+            )
+        )
+        new_job_position = jp_check.scalar_one_or_none()
+        if not new_job_position:
+            raise StructuredHTTPException(
+                404,
+                code="JOB_POSITION_NOT_FOUND",
+                message="Job position not found",
+            )
+
     await _assert_external_owner_access(
         db,
         current_user,
@@ -1281,16 +1336,26 @@ async def create_transfer(
     # Actually move the contact to the new tier
     contact.tier_id = body.to_tier_id
 
+    # Update job position if provided (SUP-0038)
+    if body.new_job_position_id:
+        contact.job_position_id = body.new_job_position_id
+
+    # SUP-0038: Invalidate existing compliance records when context changes
+    # (tier or job position changed → compliance requirements may differ)
+    await _invalidate_compliance_on_transfer(db, contact.id)
+
     await db.commit()
     await db.refresh(transfer)
 
     # Enrich response
     from_tier = await db.get(Tier, transfer.from_tier_id)
     to_tier = await db.get(Tier, transfer.to_tier_id)
+    new_job_pos = await db.get(JobPosition, transfer.new_job_position_id) if transfer.new_job_position_id else None
     d = {c.key: getattr(transfer, c.key) for c in transfer.__table__.columns}
     d["contact_name"] = f"{contact.first_name} {contact.last_name}"
     d["from_tier_name"] = from_tier.name if from_tier else None
     d["to_tier_name"] = to_tier.name if to_tier else None
+    d["new_job_position_name"] = new_job_pos.name if new_job_pos else None
     return d
 
 

--- a/app/models/common.py
+++ b/app/models/common.py
@@ -1603,11 +1603,13 @@ class TierContactTransfer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     to_tier_id: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("tiers.id"), nullable=False)
     transfer_date: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     reason: Mapped[str | None] = mapped_column(Text)
+    new_job_position_id: Mapped[PyUUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("job_positions.id"), nullable=True)
     transferred_by: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
 
     contact: Mapped["TierContact"] = relationship(foreign_keys=[contact_id])
     from_tier: Mapped["Tier"] = relationship(foreign_keys=[from_tier_id])
     to_tier: Mapped["Tier"] = relationship(foreign_keys=[to_tier_id])
+    new_job_position: Mapped["JobPosition | None"] = relationship(foreign_keys=[new_job_position_id])
     actor: Mapped["User"] = relationship(foreign_keys=[transferred_by])
 
 

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1635,11 +1635,13 @@ class TierContactTransferRead(OpsFluxSchema):
     to_tier_id: UUID
     transfer_date: datetime
     reason: str | None = None
+    new_job_position_id: UUID | None = None
     transferred_by: UUID
     created_at: datetime
     contact_name: str | None = None
     from_tier_name: str | None = None
     to_tier_name: str | None = None
+    new_job_position_name: str | None = None
 
 
 class TierContactTransferCreate(BaseModel):
@@ -1648,6 +1650,7 @@ class TierContactTransferCreate(BaseModel):
     to_tier_id: UUID
     transfer_date: datetime
     reason: str | None = None
+    new_job_position_id: UUID | None = None
 
 
 # ─── Projects / Projets ─────────────────────────────────────────────────────

--- a/apps/main/src/locales/fr/common.json
+++ b/apps/main/src/locales/fr/common.json
@@ -1357,6 +1357,10 @@
       "select_employee_help": "Choisissez l'employé à transférer",
       "destination": "Destination",
       "destination_help": "Entreprise vers laquelle l'employé sera transféré",
+      "new_job_position": "Nouveau poste (optionnel)",
+      "new_job_position_help": "Vous pouvez changer le poste de l'employé lors du transfert. Cela actualisera ses référentiels de conformité selon les exigences du nouveau poste.",
+      "new_job_position_label": "Nouveau poste",
+      "keep_current_position": "Conserver le poste actuel",
       "details": "Détails du transfert",
       "details_help": "Informations complémentaires sur le transfert",
       "reason_placeholder": "Ex: Changement de contrat, réorganisation..."

--- a/apps/main/src/pages/conformite/panels/CreateTransferPanel.tsx
+++ b/apps/main/src/pages/conformite/panels/CreateTransferPanel.tsx
@@ -14,7 +14,7 @@ import {
 import type { ActionItem } from '@/components/layout/DynamicPanel'
 import { useUIStore } from '@/stores/uiStore'
 import { useToast } from '@/components/ui/Toast'
-import { useCreateTransfer } from '@/hooks/useConformite'
+import { useCreateTransfer, useJobPositions } from '@/hooks/useConformite'
 import { useTiers, useTierContacts } from '@/hooks/useTiers'
 import type { TierContactTransferCreate } from '@/types/api'
 
@@ -42,6 +42,9 @@ function CreateTransferInner() {
   // Fetch all tiers for dropdowns
   const { data: tiersData } = useTiers({ page_size: 500 })
 
+  // Fetch job positions for the new job position selector (SUP-0038)
+  const { data: jobPositionsData } = useJobPositions({ page_size: 500 })
+
   const [selectedContactTierId, setSelectedContactTierId] = useState<string>(prefillFromTierId)
 
   // Fetch contacts for the selected tier
@@ -53,6 +56,7 @@ function CreateTransferInner() {
     to_tier_id: '',
     transfer_date: new Date().toISOString().split('T')[0],
     reason: null,
+    new_job_position_id: null,
   })
 
   // When a contact is selected, auto-populate from_tier_id with the contact's current tier.
@@ -109,6 +113,7 @@ function CreateTransferInner() {
 
   const tiers = tiersData?.items ?? []
   const contacts = Array.isArray(contactsData) ? contactsData : []
+  const jobPositions = jobPositionsData?.items ?? []
 
   return (
     <DynamicPanelShell
@@ -194,6 +199,28 @@ function CreateTransferInner() {
                       {tier.name} ({tier.code})
                     </option>
                   ))}
+              </select>
+            </DynamicPanelField>
+          </SmartFormSection>
+
+          <SmartFormSection
+            id="job_position"
+            title={t('conformite.transfers.new_job_position')}
+            level="recommended"
+            help={{ description: t('conformite.transfers.new_job_position_help') }}
+          >
+            <DynamicPanelField label={t('conformite.transfers.new_job_position_label')}>
+              <select
+                value={form.new_job_position_id ?? ''}
+                onChange={(e) => setForm({ ...form, new_job_position_id: e.target.value || null })}
+                className={panelInputClass}
+              >
+                <option value="">-- {t('conformite.transfers.keep_current_position')} --</option>
+                {jobPositions.map((jp) => (
+                  <option key={jp.id} value={jp.id}>
+                    {jp.name} ({jp.code}){jp.department ? ` - ${jp.department}` : ''}
+                  </option>
+                ))}
               </select>
             </DynamicPanelField>
           </SmartFormSection>

--- a/apps/main/src/types/api.ts
+++ b/apps/main/src/types/api.ts
@@ -1254,6 +1254,7 @@ export interface TierContactTransferCreate {
   to_tier_id: string
   transfer_date: string
   reason?: string | null
+  new_job_position_id?: string | null
 }
 
 // ── Projects / Projets ───────────────────────────────────────

--- a/tests/test_transfer_compliance_bug.py
+++ b/tests/test_transfer_compliance_bug.py
@@ -1,0 +1,335 @@
+"""
+Test de reproduction pour SUP-0038 : Transfert d'employé incomplet.
+
+Ce test démontre que :
+1. Le transfert ne réinitialise pas la conformité de l'employé
+2. Le transfert ne permet pas de changer le poste de l'employé
+"""
+import pytest
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+
+@pytest.mark.asyncio
+async def test_transfer_should_reinitialize_compliance_but_doesnt(async_client, test_entity, test_user, db):
+    """
+    REPRO : Démontrer que le transfert ne gère pas la conformité.
+
+    Scénario :
+    1. Créer un employé avec des enregistrements de conformité valides
+    2. Transférer l'employé vers une autre entreprise
+    3. Vérifier que la conformité devrait être recalculée (mais ne l'est pas)
+
+    ATTENDU : La conformité de l'employé devrait être invalidée/recalculée après transfert
+    ACTUEL : Les anciens enregistrements de conformité restent inchangés
+    """
+    from app.models.common import Tier, TierContact, ComplianceType, ComplianceRecord
+    from sqlalchemy import select
+
+    # Créer deux entreprises
+    tier_a = Tier(
+        entity_id=test_entity.id,
+        name="Company A",
+        code="COMP_A",
+        type="subcontractor",
+        active=True,
+    )
+    tier_b = Tier(
+        entity_id=test_entity.id,
+        name="Company B",
+        code="COMP_B",
+        type="subcontractor",
+        active=True,
+    )
+    db.add_all([tier_a, tier_b])
+    await db.commit()
+    await db.refresh(tier_a)
+    await db.refresh(tier_b)
+
+    # Créer un employé dans Company A
+    employee = TierContact(
+        tier_id=tier_a.id,
+        first_name="Jane",
+        last_name="Smith",
+        email="jane.smith@example.com",
+        active=True,
+    )
+    db.add(employee)
+    await db.commit()
+    await db.refresh(employee)
+
+    # Créer un type de conformité (ex: formation sécurité)
+    comp_type = ComplianceType(
+        entity_id=test_entity.id,
+        code="SAFETY_TRAINING",
+        name="Formation Sécurité",
+        category="training",
+        owner_type="tier_contact",
+        scope="permanent",
+        active=True,
+    )
+    db.add(comp_type)
+    await db.commit()
+    await db.refresh(comp_type)
+
+    # Créer un enregistrement de conformité pour l'employé (valide et vérifié)
+    comp_record = ComplianceRecord(
+        entity_id=test_entity.id,
+        compliance_type_id=comp_type.id,
+        owner_type="tier_contact",
+        owner_id=employee.id,
+        status="valid",
+        verification_status="verified",
+        verified_by=test_user.id,
+        verified_at=datetime.now(timezone.utc),
+        issued_at=datetime.now(timezone.utc),
+        created_by=test_user.id,
+        active=True,
+    )
+    db.add(comp_record)
+    await db.commit()
+    await db.refresh(comp_record)
+
+    # Vérifier que l'enregistrement existe et est actif
+    assert comp_record.active is True
+    assert comp_record.verification_status == "verified"
+
+    # Effectuer le transfert de Company A vers Company B
+    transfer_payload = {
+        "contact_id": str(employee.id),
+        "from_tier_id": str(tier_a.id),
+        "to_tier_id": str(tier_b.id),
+        "transfer_date": date.today().isoformat(),
+        "reason": "Changement de contrat",
+    }
+
+    response = await async_client.post(
+        "/api/v1/conformite/transfers",
+        json=transfer_payload,
+    )
+
+    assert response.status_code == 201, f"Transfer failed: {response.json()}"
+
+    # Vérifier que l'employé a bien été transféré
+    await db.refresh(employee)
+    assert employee.tier_id == tier_b.id
+
+    # POINT DE DÉFAILLANCE :
+    # L'ancien enregistrement de conformité devrait être invalidé ou marqué
+    # comme nécessitant une revérification, mais il reste inchangé.
+    await db.refresh(comp_record)
+
+    # Ce test DOIT échouer car le bug existe : l'enregistrement reste actif
+    # alors qu'il devrait être invalidé après le transfert
+    assert comp_record.active is False, (
+        "BUG SUP-0038: L'enregistrement de conformité devrait être invalidé "
+        "après le transfert, mais il est toujours actif. "
+        "Le système ne réinitialise pas la conformité lors d'un transfert."
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_should_allow_job_position_change_but_doesnt(async_client, test_entity, test_user, db):
+    """
+    REPRO : Démontrer que le transfert ne permet pas de changer le poste.
+
+    Scénario :
+    1. Créer un employé avec un poste initial (Technicien)
+    2. Tenter de le transférer avec un nouveau poste (Superviseur)
+    3. Vérifier que le nouveau poste devrait être appliqué (mais ne l'est pas)
+
+    ATTENDU : Le transfert devrait accepter un champ `new_job_position_id` et mettre à jour le poste
+    ACTUEL : Le champ `new_job_position_id` n'existe pas dans le schéma/API
+    """
+    from app.models.common import Tier, TierContact, JobPosition
+    from sqlalchemy import select
+
+    # Créer deux entreprises
+    tier_a = Tier(
+        entity_id=test_entity.id,
+        name="Company A",
+        code="COMP_A",
+        type="subcontractor",
+        active=True,
+    )
+    tier_b = Tier(
+        entity_id=test_entity.id,
+        name="Company B",
+        code="COMP_B",
+        type="subcontractor",
+        active=True,
+    )
+    db.add_all([tier_a, tier_b])
+    await db.commit()
+    await db.refresh(tier_a)
+    await db.refresh(tier_b)
+
+    # Créer deux postes
+    job_tech = JobPosition(
+        entity_id=test_entity.id,
+        code="TECH",
+        name="Technicien",
+        department="Operations",
+        active=True,
+    )
+    job_super = JobPosition(
+        entity_id=test_entity.id,
+        code="SUPER",
+        name="Superviseur",
+        department="Operations",
+        active=True,
+    )
+    db.add_all([job_tech, job_super])
+    await db.commit()
+    await db.refresh(job_tech)
+    await db.refresh(job_super)
+
+    # Créer un employé avec le poste "Technicien"
+    employee = TierContact(
+        tier_id=tier_a.id,
+        first_name="John",
+        last_name="Doe",
+        email="john.doe@example.com",
+        job_position_id=job_tech.id,
+        active=True,
+    )
+    db.add(employee)
+    await db.commit()
+    await db.refresh(employee)
+
+    # Vérifier que l'employé a bien le poste "Technicien"
+    assert employee.job_position_id == job_tech.id
+
+    # Tenter de transférer l'employé avec un nouveau poste "Superviseur"
+    transfer_payload = {
+        "contact_id": str(employee.id),
+        "from_tier_id": str(tier_a.id),
+        "to_tier_id": str(tier_b.id),
+        "transfer_date": date.today().isoformat(),
+        "reason": "Promotion",
+        "new_job_position_id": str(job_super.id),  # Nouveau champ attendu
+    }
+
+    response = await async_client.post(
+        "/api/v1/conformite/transfers",
+        json=transfer_payload,
+    )
+
+    # Le transfert devrait réussir même avec le nouveau champ
+    # Mais actuellement, il peut soit :
+    # - Ignorer le champ (422 ou le champ est ignoré)
+    # - Échouer avec une erreur de validation
+
+    # Si l'API ignore le champ, le test échoue ici car le poste ne change pas
+    if response.status_code == 201:
+        # L'API a accepté le transfert, vérifions si le poste a changé
+        await db.refresh(employee)
+
+        # POINT DE DÉFAILLANCE :
+        # Le poste devrait avoir changé vers "Superviseur", mais il reste "Technicien"
+        assert employee.job_position_id == job_super.id, (
+            f"BUG SUP-0038: Le poste de l'employé devrait être mis à jour "
+            f"vers {job_super.id} (Superviseur), mais il est toujours "
+            f"{employee.job_position_id} (Technicien). "
+            f"Le transfert ne permet pas de changer le poste."
+        )
+    else:
+        # L'API a rejeté le transfert à cause du champ inconnu
+        pytest.fail(
+            f"BUG SUP-0038: L'API a rejeté le transfert avec le champ "
+            f"'new_job_position_id' (status {response.status_code}). "
+            f"Le schéma TierContactTransferCreate ne supporte pas "
+            f"le changement de poste pendant le transfert. "
+            f"Réponse: {response.json()}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_transfer_timeline_should_be_queryable(async_client, test_entity, test_user, db):
+    """
+    REPRO : Démontrer qu'il n'y a pas de vue timeline des transferts.
+
+    Scénario :
+    1. Créer un employé
+    2. Faire plusieurs transferts successifs
+    3. Tenter de récupérer une timeline organisée chronologiquement
+
+    ATTENDU : Un endpoint devrait retourner l'historique des transferts sous forme de timeline
+    ACTUEL : On peut lister les transferts, mais pas de vue timeline structurée
+    """
+    from app.models.common import Tier, TierContact
+    from sqlalchemy import select
+
+    # Créer trois entreprises
+    tier_a = Tier(entity_id=test_entity.id, name="Company A", code="COMP_A", type="subcontractor", active=True)
+    tier_b = Tier(entity_id=test_entity.id, name="Company B", code="COMP_B", type="subcontractor", active=True)
+    tier_c = Tier(entity_id=test_entity.id, name="Company C", code="COMP_C", type="subcontractor", active=True)
+    db.add_all([tier_a, tier_b, tier_c])
+    await db.commit()
+    await db.refresh(tier_a)
+    await db.refresh(tier_b)
+    await db.refresh(tier_c)
+
+    # Créer un employé
+    employee = TierContact(
+        tier_id=tier_a.id,
+        first_name="Alice",
+        last_name="Wonder",
+        email="alice@example.com",
+        active=True,
+    )
+    db.add(employee)
+    await db.commit()
+    await db.refresh(employee)
+
+    # Faire deux transferts successifs : A -> B -> C
+    transfer1_payload = {
+        "contact_id": str(employee.id),
+        "from_tier_id": str(tier_a.id),
+        "to_tier_id": str(tier_b.id),
+        "transfer_date": "2025-01-01",
+        "reason": "Premier transfert",
+    }
+    transfer2_payload = {
+        "contact_id": str(employee.id),
+        "from_tier_id": str(tier_b.id),
+        "to_tier_id": str(tier_c.id),
+        "transfer_date": "2025-06-01",
+        "reason": "Deuxième transfert",
+    }
+
+    resp1 = await async_client.post("/api/v1/conformite/transfers", json=transfer1_payload)
+    assert resp1.status_code == 201
+
+    resp2 = await async_client.post("/api/v1/conformite/transfers", json=transfer2_payload)
+    assert resp2.status_code == 201
+
+    # Récupérer l'historique des transferts pour cet employé
+    response = await async_client.get(
+        "/api/v1/conformite/transfers",
+        params={"contact_id": str(employee.id)}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # On peut lister les transferts, mais il n'y a pas de structure "timeline"
+    # organisée chronologiquement avec les périodes dans chaque entreprise
+    assert "items" in data
+    assert len(data["items"]) == 2
+
+    # POINT DE DÉFAILLANCE (plus léger) :
+    # Il faudrait idéalement un endpoint dédié qui structure les données en timeline
+    # Par exemple : GET /api/v1/conformite/contacts/{id}/timeline
+    # qui retournerait :
+    # [
+    #   {"tier_name": "Company A", "from": null, "to": "2025-01-01"},
+    #   {"tier_name": "Company B", "from": "2025-01-01", "to": "2025-06-01"},
+    #   {"tier_name": "Company C", "from": "2025-06-01", "to": null},
+    # ]
+    #
+    # Actuellement, le frontend doit reconstruire cette timeline manuellement
+    # à partir de la liste des transferts.
+    # Ce test ne va pas échouer, mais documente le manque.
+    print("INFO: La timeline existe sous forme de liste de transferts, "
+          "mais pas sous forme structurée chronologique.")


### PR DESCRIPTION
## Ticket

**SUP-0038** — Transfert employé incompletement implémenté

## Problème

Le transfert d'employé existait côté frontend et backend, mais l'implémentation était trop sommaire :

1. ❌ Pas de gestion de la conformité : les enregistrements de conformité n'étaient pas invalidés lors du transfert
2. ❌ Impossibilité de changer le poste pendant le transfert
3. ❌ Pas d'affichage du profil complet de l'employé (historique, conformité)
4. ❌ Pas de timeline organisée des entreprises

## Solution implémentée

### Backend

1. **Migration 161** : Ajout du champ `new_job_position_id` à `tier_contact_transfers`
2. **Modèle** : Mise à jour de `TierContactTransfer` avec le nouveau champ et sa relation
3. **Schéma** : Ajout de `new_job_position_id` à `TierContactTransferCreate` et `TierContactTransferRead`
4. **Endpoint `create_transfer`** enrichi pour :
   - Valider le nouveau poste si fourni
   - Mettre à jour `contact.job_position_id` lors du transfert
   - Invalider les enregistrements de conformité existants via `_invalidate_compliance_on_transfer`
   - Enrichir la réponse avec le nom du nouveau poste
5. **Fonction `_invalidate_compliance_on_transfer`** :
   - Marque les `ComplianceRecord` actifs comme `active=False` (préserve l'audit trail)
   - Émet un événement pour traçabilité
   - Force la revérification de la conformité dans le nouveau contexte

### Frontend

1. **CreateTransferPanel** :
   - Ajout d'un sélecteur de poste (utilise `useJobPositions`)
   - Option "Conserver le poste actuel" par défaut
   - Section dédiée "Nouveau poste (optionnel)" avec niveau `recommended`
2. **Types TypeScript** : Mise à jour de `TierContactTransferCreate`
3. **Traductions** : Ajout des clés françaises pour les nouveaux champs

### Tests

- **test_transfer_compliance_bug.py** : Tests de reproduction démontrant :
  - Le transfert devrait invalider la conformité (test échoue actuellement)
  - Le transfert devrait permettre de changer le poste (test échoue actuellement)
  - La timeline des transferts devrait être structurée (documentation)

## Impact

### Conformité
- ✅ Les enregistrements de conformité sont invalidés lors du transfert
- ✅ Les responsables conformité doivent revérifier/ré-émettre les documents pour le nouveau contexte
- ✅ Préservation de l'audit trail (records marqués `active=False` au lieu de supprimés)

### UX
- ✅ Possibilité de changer le poste pendant le transfert (économie d'une opération manuelle)
- ✅ Sélecteur de poste intuitif avec départements affichés
- ✅ Message d'aide expliquant l'impact sur la conformité

### Métier
- ✅ Atomicité : transfert + changement de poste en une seule opération
- ✅ Cohérence : les référentiels de conformité correspondent au nouveau contexte
- ✅ Traçabilité : tous les changements sont loggés

## Statistiques

- **Fichiers modifiés** : 8
- **Lignes ajoutées** : ~470
- **Lignes supprimées** : ~3
- **Migration** : 1 (ajout colonne nullable, pas de data migration)

## Points non couverts (hors scope limite 500 lignes)

- ❌ Affichage complet du profil employé dans le formulaire (historique, antécédents)
- ❌ Timeline structurée des entreprises (liste simple disponible via API)
- ❌ Endpoint dédié `/contacts/{id}/timeline` pour une vue chronologique

Ces améliorations UX peuvent être implémentées dans un ticket ultérieur.

## Tests

Les tests de reproduction sont présents dans `tests/test_transfer_compliance_bug.py` mais n'ont pas été exécutés car l'environnement Python n'est pas configuré dans le conteneur de build. Ils peuvent être exécutés en local avec `pytest tests/test_transfer_compliance_bug.py`.

## Build

✅ TypeScript build passe sans erreur (warning de dépréciation `baseUrl` ignoré)

Agent-Run: de5a3b23-6ff0-415a-8eea-9093149c38b0