### PR TITLE
fix(conformite): 4 bugs UX panneau Référentiel + Nouvel enregistrement

### DIFF
--- a/apps/main/src/pages/conformite/panels/CreateComplianceRecordPanel.tsx
+++ b/apps/main/src/pages/conformite/panels/CreateComplianceRecordPanel.tsx
@@ -165,7 +165,10 @@ function CreateComplianceRecordInner() {
       variant: 'primary',
       priority: 100,
       loading: createRecord.isPending || uploading,
-      disabled: createRecord.isPending || uploading || !file,
+      // Previously also disabled when !file, which made the wizard look broken
+      // (Terminer silently did nothing). We now let the button click reach
+      // handleCreate, which raises a clear toast when the attachment is missing.
+      disabled: createRecord.isPending || uploading,
       tooltip: !file ? t('conformite.records.errors.attachment_required') : undefined,
       onClick: handleCreate,
     },
@@ -178,6 +181,10 @@ function CreateComplianceRecordInner() {
       icon={<FileCheck size={14} className="text-primary" />}
       actionItems={actionItems}
     >
+      <form
+        id="create-compliance-record-form"
+        onSubmit={(e) => { e.preventDefault(); handleCreate() }}
+      >
       <PanelContentLayout>
         <SmartFormToolbar />
         <SmartFormSimpleHint />
@@ -363,18 +370,22 @@ function CreateComplianceRecordInner() {
           )}
         </SmartFormSection>
       {_ctx?.mode === 'wizard' && (
-
         <SmartFormWizardNav
-
-          onSubmit={() => document.querySelector('form')?.requestSubmit()}
-
-          onCancel={() => {}}
-
+          /* Bug fix : previously the wizard called document.querySelector('form')
+             but no <form> existed in the tree, so the final "Terminer" button
+             silently did nothing. Now there's a real <form id="create-compliance-record-form">
+             above and we target it explicitly. */
+          onSubmit={() => {
+            const formEl = document.getElementById('create-compliance-record-form') as HTMLFormElement | null
+            if (formEl) formEl.requestSubmit()
+            else handleCreate()
+          }}
+          onCancel={closeDynamicPanel}
         />
-
       )}
 
       </PanelContentLayout>
+      </form>
     </DynamicPanelShell>
   )
 }

--- a/apps/main/src/pages/conformite/panels/CreateTypePanel.tsx
+++ b/apps/main/src/pages/conformite/panels/CreateTypePanel.tsx
@@ -37,11 +37,28 @@ function CreateTypeInner() {
   const { categoryOptions } = useConformiteDictionaryState()
   const [form, setForm] = useState<ComplianceTypeCreate>({
     category: 'formation',
+    code: '',
     name: '',
     description: null,
     validity_days: null,
     is_mandatory: false,
+    compliance_source: 'opsflux',
+    external_provider: null,
+    external_mapping: null,
   })
+  // Slugify a free-text name into UPPER_SNAKE for the code field.
+  const slugifyCode = (s: string) => s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase()
+    .slice(0, 50)
+  // Track whether the user manually edited the code so we don't overwrite it.
+  const [codeIsDirty, setCodeIsDirty] = useState(false)
+  // When external mapping is needed, expose a simple "key=value" editor.
+  const [mappingKey, setMappingKey] = useState('')
+  const [mappingValue, setMappingValue] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -91,11 +108,35 @@ function CreateTypeInner() {
             <div className="@container space-y-5">
               <SmartFormSection id="t_common_information" title={t('common.information')} level="essential" help={{ description: t('common.information') }}>
                 <FormGrid>
-                  <DynamicPanelField label={t('common.code_field')}>
-                    <span className="text-sm font-mono text-muted-foreground italic">Auto-généré à la création</span>
+                  <DynamicPanelField label={t('common.code_field')} required>
+                    <input
+                      type="text"
+                      required
+                      value={form.code ?? ''}
+                      onChange={(e) => { setCodeIsDirty(true); setForm({ ...form, code: slugifyCode(e.target.value) }) }}
+                      className={`${panelInputClass} font-mono`}
+                      placeholder="FORMATION_HSE_N1"
+                      pattern="[A-Z0-9_]+"
+                      title="Lettres majuscules, chiffres et underscores"
+                    />
                   </DynamicPanelField>
                   <DynamicPanelField label={t('common.name_field')} required>
-                    <input type="text" required value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className={panelInputClass} placeholder="Formation HSE Niveau 1" />
+                    <input
+                      type="text"
+                      required
+                      value={form.name}
+                      onChange={(e) => {
+                        const next = e.target.value
+                        setForm((f) => ({
+                          ...f,
+                          name: next,
+                          // Auto-suggest the code from the name while the user hasn't typed in the code box yet.
+                          code: codeIsDirty ? f.code : slugifyCode(next),
+                        }))
+                      }}
+                      className={panelInputClass}
+                      placeholder="Formation HSE Niveau 1"
+                    />
                   </DynamicPanelField>
                   <DynamicPanelField label="Validité (jours)">
                     <input type="number" value={form.validity_days ?? ''} onChange={(e) => setForm({ ...form, validity_days: e.target.value ? Number(e.target.value) : null })} className={panelInputClass} placeholder="365 (vide = permanent)" />
@@ -121,6 +162,93 @@ function CreateTypeInner() {
               </label>
             </div>
           </SectionColumns>
+
+          {/* Source & vérification externe — permet de raccorder un référentiel à RiseUp ou autre provider externe. */}
+          <SmartFormSection
+            id="t_common_source"
+            title="Source & vérification externe"
+            level="advanced"
+            help={{
+              description:
+                'Définit comment les enregistrements de ce type sont vérifiés. "OpsFlux" = saisie manuelle. "Externe" = vérification automatique via un provider tiers (ex. RiseUp pour les formations e-learning). "Mixte" = les deux modes acceptés.',
+            }}
+          >
+            <FormGrid>
+              <DynamicPanelField label="Source de conformité" required>
+                <select
+                  value={form.compliance_source ?? 'opsflux'}
+                  onChange={(e) => {
+                    const next = e.target.value as 'opsflux' | 'external' | 'both'
+                    setForm((f) => ({
+                      ...f,
+                      compliance_source: next,
+                      // Reset provider/mapping when going back to internal-only.
+                      external_provider: next === 'opsflux' ? null : f.external_provider,
+                      external_mapping: next === 'opsflux' ? null : f.external_mapping,
+                    }))
+                  }}
+                  className={panelInputClass}
+                >
+                  <option value="opsflux">OpsFlux (interne)</option>
+                  <option value="external">Externe (provider tiers)</option>
+                  <option value="both">Mixte (interne + externe)</option>
+                </select>
+              </DynamicPanelField>
+              {form.compliance_source !== 'opsflux' && (
+                <DynamicPanelField label="Provider externe" required>
+                  <select
+                    value={form.external_provider ?? ''}
+                    onChange={(e) => setForm({ ...form, external_provider: e.target.value || null })}
+                    className={panelInputClass}
+                    required
+                  >
+                    <option value="">Choisir un provider…</option>
+                    <option value="riseup">RiseUp (LMS)</option>
+                  </select>
+                </DynamicPanelField>
+              )}
+              {form.compliance_source !== 'opsflux' && form.external_provider === 'riseup' && (
+                <DynamicPanelField label="Mapping RiseUp" span="full">
+                  <p className="mb-1 text-xs text-muted-foreground">
+                    Lie ce référentiel OpsFlux à un identifiant côté RiseUp (ex. <code className="font-mono">riseup_cert_id = 2</code>).
+                  </p>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={mappingKey || (form.external_mapping ? Object.keys(form.external_mapping)[0] || '' : '')}
+                      onChange={(e) => {
+                        const k = e.target.value
+                        setMappingKey(k)
+                        const v = mappingValue || (form.external_mapping ? Object.values(form.external_mapping)[0] || '' : '')
+                        setForm({ ...form, external_mapping: k && v ? { [k]: String(v) } : null })
+                      }}
+                      className={`${panelInputClass} flex-1 font-mono text-xs`}
+                      placeholder="riseup_cert_id"
+                      list="riseup-mapping-keys"
+                    />
+                    <datalist id="riseup-mapping-keys">
+                      <option value="riseup_cert_id" />
+                      <option value="riseup_training_id" />
+                      <option value="riseup_module_id" />
+                    </datalist>
+                    <span className="text-sm text-muted-foreground self-center">=</span>
+                    <input
+                      type="text"
+                      value={mappingValue || (form.external_mapping ? String(Object.values(form.external_mapping)[0] ?? '') : '')}
+                      onChange={(e) => {
+                        const v = e.target.value
+                        setMappingValue(v)
+                        const k = mappingKey || (form.external_mapping ? Object.keys(form.external_mapping)[0] || '' : '')
+                        setForm({ ...form, external_mapping: k && v ? { [k]: String(v) } : null })
+                      }}
+                      className={`${panelInputClass} flex-1 font-mono text-xs`}
+                      placeholder="2"
+                    />
+                  </div>
+                </DynamicPanelField>
+              )}
+            </FormGrid>
+          </SmartFormSection>
         {_ctx?.mode === 'wizard' && (
 
           <SmartFormWizardNav

--- a/apps/main/src/pages/conformite/panels/TypeDetailPanel.tsx
+++ b/apps/main/src/pages/conformite/panels/TypeDetailPanel.tsx
@@ -40,6 +40,11 @@ export function TypeDetailPanel({ id }: { id: string }) {
   const [centerStart, setCenterStart] = useState('')
   const [centerEnd, setCenterEnd] = useState('')
   const [expandedCenterId, setExpandedCenterId] = useState<string | null>(null)
+  // Issuer creation form is collapsed by default — the previous layout kept all
+  // 5 fields permanently visible above the list which made the empty state look
+  // like a half-filled form and pushed the primary "+ Ajouter" action to the
+  // bottom-right of the grid, far from the section heading.
+  const [showAddCenterForm, setShowAddCenterForm] = useState(false)
   const { data: availableCenters } = useAuthorizationCenters({ page_size: 200 })
   const { data: authorizedCenters } = useTypeAuthorizedCenters(id)
   const addAuthorizedCenter = useAddTypeAuthorizedCenter()
@@ -84,8 +89,17 @@ export function TypeDetailPanel({ id }: { id: string }) {
     setCenterNotes('')
     setCenterStart('')
     setCenterEnd('')
+    setShowAddCenterForm(false) // Collapse the form back after a successful add.
     toast({ title: t('conformite.types_panel.center_added'), variant: 'success' })
   }, [addAuthorizedCenter, centerEnd, centerNotes, centerStart, id, selectedCenterId, toast, t])
+
+  const cancelAddCenter = useCallback(() => {
+    setSelectedCenterId('')
+    setCenterNotes('')
+    setCenterStart('')
+    setCenterEnd('')
+    setShowAddCenterForm(false)
+  }, [])
 
   const formatAccreditationPeriod = useCallback((start?: string | null, end?: string | null) => {
     if (!start && !end) return t('conformite.types_panel.accreditation_period_missing')
@@ -163,6 +177,64 @@ export function TypeDetailPanel({ id }: { id: string }) {
               />
             </DetailFieldGrid>
           </FormSection>
+          {/* Source & vérification externe — édition inline du raccordement au provider externe (RiseUp, etc.). */}
+          <FormSection title="Source & vérification externe">
+            <DetailFieldGrid>
+              <InlineEditableSelect
+                label="Source"
+                value={ct.compliance_source || 'opsflux'}
+                displayValue={
+                  ct.compliance_source === 'external'
+                    ? 'Externe (provider tiers)'
+                    : ct.compliance_source === 'both'
+                    ? 'Mixte (interne + externe)'
+                    : 'OpsFlux (interne)'
+                }
+                options={[
+                  { value: 'opsflux', label: 'OpsFlux (interne)' },
+                  { value: 'external', label: 'Externe (provider tiers)' },
+                  { value: 'both', label: 'Mixte (interne + externe)' },
+                ]}
+                onSave={(v) => {
+                  // When going back to internal-only, drop the external provider/mapping to stay coherent.
+                  if (v === 'opsflux') {
+                    updateType.mutate({ id, payload: { compliance_source: 'opsflux', external_provider: null, external_mapping: null } })
+                  } else {
+                    handleSave('compliance_source', v)
+                  }
+                }}
+              />
+              {ct.compliance_source !== 'opsflux' && (
+                <InlineEditableSelect
+                  label="Provider externe"
+                  value={ct.external_provider || ''}
+                  displayValue={ct.external_provider === 'riseup' ? 'RiseUp (LMS)' : '—'}
+                  options={[
+                    { value: 'riseup', label: 'RiseUp (LMS)' },
+                  ]}
+                  onSave={(v) => handleSave('external_provider', v || null)}
+                />
+              )}
+              {ct.compliance_source !== 'opsflux' && ct.external_provider === 'riseup' && (
+                <InlineEditableRow
+                  label="Mapping RiseUp (cert id)"
+                  value={ct.external_mapping?.riseup_cert_id ?? ''}
+                  displayValue={
+                    ct.external_mapping?.riseup_cert_id
+                      ? `riseup_cert_id = ${ct.external_mapping.riseup_cert_id}`
+                      : '— non mappé'
+                  }
+                  onSave={(v) => {
+                    const next = (v || '').trim()
+                    updateType.mutate({
+                      id,
+                      payload: { external_mapping: next ? { riseup_cert_id: next } : null },
+                    })
+                  }}
+                />
+              )}
+            </DetailFieldGrid>
+          </FormSection>
           <FormSection title={t('common.description')}>
             {/* Full-width — FormSection labels this block already,
                 the inner label row was cramping multiline content. */}
@@ -190,51 +262,80 @@ export function TypeDetailPanel({ id }: { id: string }) {
       )}
       {detailTab === 'emetteurs' && (
         <PanelContentLayout>
-          <FormSection title={t('conformite.types_panel.centers_title')}>
-            <div className="@container space-y-3">
-              <div className="grid grid-cols-1 gap-2 @[760px]:grid-cols-[minmax(0,1.2fr)_minmax(120px,.6fr)_minmax(120px,.6fr)_minmax(0,1fr)_auto]">
-                <select
-                  value={selectedCenterId}
-                  onChange={(e) => setSelectedCenterId(e.target.value)}
-                  className={panelInputClass}
-                >
-                  <option value="">{t('conformite.types_panel.select_center_placeholder')}</option>
-                  {(availableCenters?.items ?? []).map((center) => (
-                    <option key={center.id} value={center.id}>
-                      {center.name}{center.authorization_center_code ? ` · ${center.authorization_center_code}` : ''}
-                    </option>
-                  ))}
-                </select>
-                <input
-                  type="date"
-                  value={centerStart}
-                  onChange={(e) => setCenterStart(e.target.value)}
-                  className={panelInputClass}
-                  aria-label={t('conformite.types_panel.accreditation_starts_at')}
-                />
-                <input
-                  type="date"
-                  value={centerEnd}
-                  onChange={(e) => setCenterEnd(e.target.value)}
-                  className={panelInputClass}
-                  aria-label={t('conformite.types_panel.accreditation_ends_at')}
-                />
-                <input
-                  value={centerNotes}
-                  onChange={(e) => setCenterNotes(e.target.value)}
-                  className={panelInputClass}
-                  placeholder={t('conformite.types_panel.center_notes_placeholder')}
-                />
+          <FormSection
+            title={t('conformite.types_panel.centers_title')}
+            /* `headerExtra` is the canonical FormSection slot for right-aligned
+               header actions — using it keeps spacing/typography consistent with
+               other sections (vs an ad-hoc div above the section). */
+            headerExtra={
+              !showAddCenterForm ? (
                 <button
                   type="button"
-                  onClick={handleAddCenter}
-                  disabled={!selectedCenterId || addAuthorizedCenter.isPending}
+                  onClick={() => setShowAddCenterForm(true)}
                   className="btn btn-primary btn-sm"
                 >
-                  {addAuthorizedCenter.isPending ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
-                  {t('common.add')}
+                  <Plus size={12} />
+                  {t('conformite.types_panel.add_center') || t('common.add')}
                 </button>
-              </div>
+              ) : undefined
+            }
+          >
+            <div className="@container space-y-3">
+              {/* Collapsible add-center form — hidden by default to keep the section header clean.
+                  Replaces the always-visible 5-field grid that pushed the primary action to the bottom. */}
+              {showAddCenterForm && (
+                <div className="rounded-md border border-border bg-background-subtle p-3 space-y-2">
+                  <div className="grid grid-cols-1 gap-2 @[760px]:grid-cols-[minmax(0,1.2fr)_minmax(120px,.6fr)_minmax(120px,.6fr)_minmax(0,1fr)]">
+                    <select
+                      value={selectedCenterId}
+                      onChange={(e) => setSelectedCenterId(e.target.value)}
+                      className={panelInputClass}
+                      autoFocus
+                    >
+                      <option value="">{t('conformite.types_panel.select_center_placeholder')}</option>
+                      {(availableCenters?.items ?? []).map((center) => (
+                        <option key={center.id} value={center.id}>
+                          {center.name}{center.authorization_center_code ? ` · ${center.authorization_center_code}` : ''}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      type="date"
+                      value={centerStart}
+                      onChange={(e) => setCenterStart(e.target.value)}
+                      className={panelInputClass}
+                      aria-label={t('conformite.types_panel.accreditation_starts_at')}
+                    />
+                    <input
+                      type="date"
+                      value={centerEnd}
+                      onChange={(e) => setCenterEnd(e.target.value)}
+                      className={panelInputClass}
+                      aria-label={t('conformite.types_panel.accreditation_ends_at')}
+                    />
+                    <input
+                      value={centerNotes}
+                      onChange={(e) => setCenterNotes(e.target.value)}
+                      className={panelInputClass}
+                      placeholder={t('conformite.types_panel.center_notes_placeholder')}
+                    />
+                  </div>
+                  <div className="flex items-center justify-end gap-2">
+                    <button type="button" onClick={cancelAddCenter} className="btn btn-ghost btn-sm">
+                      {t('common.cancel')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleAddCenter}
+                      disabled={!selectedCenterId || addAuthorizedCenter.isPending}
+                      className="btn btn-primary btn-sm"
+                    >
+                      {addAuthorizedCenter.isPending ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+                      {t('conformite.types_panel.confirm_add_center') || t('common.confirm') || t('common.add')}
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {authorizedCenters?.length ? (
                 <div className="divide-y divide-border overflow-hidden rounded-md border border-border bg-background">


### PR DESCRIPTION
Bug #1 — CreateTypePanel : champ Code visible et requis
  Le placeholder "Auto-généré à la création" était mensonger : l'API
  exige `code` au POST. Remplacé par un input éditable avec auto-suggest
  depuis le name (slugify UPPER_SNAKE) tant que l'utilisateur ne tape pas
  manuellement dans le champ.

Bug #2 — CreateTypePanel + TypeDetailPanel : section "Source & vérif externe"
  L'utilisateur ne pouvait pas raccorder un référentiel à RiseUp via l'UI,
  malgré le message d'erreur qui suggérait de le faire dans Conformité > Types.
  Ajout des 3 champs manquants (le backend les supportait déjà) :
    - compliance_source : opsflux | external | both
    - external_provider : riseup (extensible)
    - external_mapping : éditeur key=value avec datalist Les champs externe/mapping s'affichent en cascade conditionnelle.

Bug #3 — CreateComplianceRecordPanel : Assistant Terminer sans effet
  Le SmartFormWizardNav.onSubmit faisait document.querySelector('form')
  mais aucun <form> n'existait dans le panel, donc Terminer en étape 3/3
  ne déclenchait rien. Wrapping du PanelContentLayout dans
  <form id="create-compliance-record-form"> ciblé explicitement.
  Bonus : le bouton "Créer" du header n'est plus disabled quand !file —
  handleCreate raise déjà un toast clair en l'absence de PJ, donc le
  comportement silencieux trompait l'utilisateur.

Bug #4 — TypeDetailPanel onglet Émetteurs : bouton + Ajouter mal placé
  Auparavant : 5 inputs et un bouton Ajouter en grid permanent au-dessus
  de la liste. Sur mobile/petit conteneur la grille tombait en colonne et
  le bouton se retrouvait tout en bas, alors que la liste affichait
  "Aucun centre habilité" juste après → contradiction visuelle.
  Maintenant : bouton "+ Ajouter un émetteur" dans headerExtra de la
  FormSection (haut-droite, cohérent avec le reste de l'app). Form
  d'ajout caché par défaut, dépliable au clic, avec boutons
  Annuler / Confirmer dédiés.